### PR TITLE
Update notebook copies without output

### DIFF
--- a/tutorials/ionmobility/_meier-tims-ccs.ipynb
+++ b/tutorials/ionmobility/_meier-tims-ccs.ipynb
@@ -98,7 +98,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ccs_df = pd.read_csv(\"https://github.com/ProteomicsML/IonMobility/blob/main/datasets/Meier_IM_CCS/combined_sm.zip?raw=true\", compression=\"zip\", index_col=0)"
+    "ccs_df = pd.read_csv(\"https://github.com/ProteomicsML/ProteomicsML/blob/main/datasets/ionmobility/Meier_IM_CCS/combined_sm.zip?raw=true\", compression=\"zip\", index_col=0)"
    ]
   },
   {
@@ -117,7 +117,8 @@
    "outputs": [],
    "source": [
     "#ccs_df = pd.read_csv(\n",
-    "#    \"https://raw.githubusercontent.com/ProteomicsML/IonMobility/main/datasets/VanPuyvelde_TWIMS_CCS/TWIMSpeptideCCS.tsv\",\n",
+    "#    \"https://github.com/ProteomicsML/ProteomicsML/raw/main/datasets/ionmobility/VanPuyvelde_TWIMS_CCS/TWIMSpeptideCCS.tsv.gz\",\n",
+    "#    compression=\"gzip\",\n",
     "#    low_memory=False,\n",
     "#    sep=\"\\t\"\n",
     "#)"

--- a/tutorials/ionmobility/meier-tims-ccs.ipynb
+++ b/tutorials/ionmobility/meier-tims-ccs.ipynb
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "db9040cf",
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
This automated PR generates new copies of all notebooks without output.
The automatically generated versions are prepended with an underscore
and can be used to open in Colab for interactive usage.