### PR TITLE
Add cookie consent form for Google Analytics

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
         with:
-          version: "1.2.157"
+          version: "1.3.340"
 
       - name: Render website
         uses: quarto-dev/quarto-actions/render@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
         with:
-          version: "1.2.90"
+          version: "1.3.340"
 
       - name: Test rendering Quarto Project
         uses: quarto-dev/quarto-actions/render@v2

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -54,9 +54,11 @@ website:
   repo-actions: [source, edit]
   page-footer: |
     <small>This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons CC BY 4.0</a> license.</small>
+  cookie-consent:
+    type: express
+    style: interstitial
   google-analytics:
     tracking-id: G-VVRMZHT2W2
-    storage: none
     anonymize-ip: true
   open-graph: true
   twitter-card: true

--- a/static/css/custom-styles.css
+++ b/static/css/custom-styles.css
@@ -2,6 +2,15 @@
     max-width: 100%;
     width: auto;
 }
+
 .navbar-logo {
     max-height: 48px;
+}
+
+.termsfeed-com---palette-light .cc-nb-okagree,
+.termsfeed-com---palette-light .cc-nb-reject,
+.termsfeed-com---palette-light .cc-cp-foot-save,
+.termsfeed-com---pc-dialog input[type="checkbox"].cc-custom-checkbox:checked+label:before {
+    background-color: #205380;
+    background: #205380;
 }


### PR DESCRIPTION
This PR enables the built-in cookie consent banner from Quarto (which uses TermsFeed). Although we only use this for anonymized tracking cookies for Google Analytics, the options include all default levels of consent, including customized advertisement cookies. ProteomicsML only uses the functional and tracking consent levels, not the advertising level. Unfortunately, the requested levels cannot be configured individually through Quarto.